### PR TITLE
Add test for createUser with mismatched password and confirmation

### DIFF
--- a/app/graphql/mutations/users/create_user.rb
+++ b/app/graphql/mutations/users/create_user.rb
@@ -9,7 +9,7 @@ module Mutations
         if user_params[:password] == user_params[:password_confirmation]
           User.create(user_params)
         else
-          GraphQL::ExecutionError.new('passwords must match')
+          GraphQL::ExecutionError.new('password and confirmation must match')
         end
       end
     end

--- a/spec/mutations/users/create_user_spec.rb
+++ b/spec/mutations/users/create_user_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 module Mutations
   module Users
     RSpec.describe CreateUser, type: :request do
-      it 'A user can be created' do
+      it 'can create a user' do
         post '/graphql', params: { query: query(email: 'user@tomo.com', username: 'mari', password: '123', password_confirmation: '123') }
 
         parsed = JSON.parse(response.body, symbolize_names: true)
@@ -16,6 +16,18 @@ module Mutations
 
         expect(user[:email]).to be_a(String)
         expect(user[:email]).to eq('user@tomo.com')
+
+        expect(User.all.count).to eq(1)
+      end
+
+      it 'cannot create a user if password does not match password confirmation' do
+        post '/graphql', params: { query: query(email: 'user@tomo.com', username: 'mari', password: '123', password_confirmation: 'abc') }
+
+        parsed = JSON.parse(response.body, symbolize_names: true)
+        
+        expect(parsed[:errors][0][:message]).to eq('password and confirmation must match')
+        
+        expect(User.all.count).to eq(0)
       end
 
       def query(email:, username:, password:, password_confirmation:)


### PR DESCRIPTION
### What was changed?
- Added sad path test for user signing up with password not equal to password confirmation (saw this was missed in simplecov coverage)
- Updated error messaging

### Have Tests Been Added?
- [ ] No.
- [ ] Yes, but all tests are not passing.
- [x] Yes, and all are passing.

### Issues:
* Closes #90

### Tracking and Documentation Consistency:
- [x] Updated README where necessary
- [x] Added appropriate labels
- [x] Addressed any rubocop violations
- [x] Added comments on my pull request, particularly in hard-to-understand areas
