### PR TITLE
Change fluency_level to input of integer instead of string

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,18 +246,18 @@ Stack: Rails, GraphQL, RSpec, Travis CI, Heroku
       ```
       argument :user_id, ID, required: true
       argument :language_id, ID, required: true
-      argument :fluency_level, String, required: true
+      argument :fluency_level, Integer, required: true
       ```
-    - `fluency_level: "0"`: 'native', `fluency_level: "1"`: 'target'
+    - `fluency_level: 0`: 'native', `fluency_level: 1`: 'target'
     - <details>
         <summary>Example request</summary>
 
         ```
         mutation {
           createUserLanguage(input: { params: {
-            userId: "1",
-            languageId: "1",
-            fluencyLevel: "1"
+            userId: 1,
+            languageId: 1,
+            fluencyLevel: 1
           }}) {
             id
             userId

--- a/app/graphql/mutations/user_languages/create_user_language.rb
+++ b/app/graphql/mutations/user_languages/create_user_language.rb
@@ -5,9 +5,7 @@ module Mutations
       type Types::UserLanguageType
 
       def resolve(params:)
-        user_language_params = Hash params
-        user_language_params[:fluency_level] = user_language_params[:fluency_level].to_i
-        UserLanguage.create(user_language_params)
+        UserLanguage.create(params.to_hash)
       end
     end
   end

--- a/app/graphql/mutations/users/create_user.rb
+++ b/app/graphql/mutations/users/create_user.rb
@@ -11,7 +11,13 @@ module Mutations
         email_taken = User.exists?(email: user_params[:email])
         if passwords_match && !username_taken && !email_taken
           User.create(user_params)
-        elsif !passwords_match
+        else
+          handle_errors(passwords_match, username_taken, email_taken)
+        end
+      end
+
+      def handle_errors(passwords_match, username_taken, email_taken)
+        if !passwords_match
           GraphQL::ExecutionError.new('password and confirmation must match')
         elsif username_taken
           GraphQL::ExecutionError.new('That username is already taken')

--- a/app/graphql/types/input/user_language_input_type.rb
+++ b/app/graphql/types/input/user_language_input_type.rb
@@ -3,7 +3,7 @@ module Types
     class UserLanguageInputType < Types::BaseInputObject
       argument :user_id, ID, required: true
       argument :language_id, ID, required: true
-      argument :fluency_level, String, required: true
+      argument :fluency_level, Integer, required: true
     end
   end
 end

--- a/spec/mutations/user_language/create_user_language_spec.rb
+++ b/spec/mutations/user_language/create_user_language_spec.rb
@@ -66,7 +66,7 @@ module Mutations
             createUserLanguage(input: { params: {
               languageId: "#{language_id}"
               userId: "#{user_id}"
-              fluencyLevel: "#{fluency_level}"
+              fluencyLevel: #{fluency_level}
             }}) {
               id
               languageId

--- a/spec/mutations/user_language/create_user_language_spec.rb
+++ b/spec/mutations/user_language/create_user_language_spec.rb
@@ -45,7 +45,7 @@ module Mutations
         expect(user_lang[:fluencyLevel]).to be_a(String)
         expect(user_lang[:fluencyLevel]).to eq('native')
 
-        expect(UserLanguage.all.count).to eq(0)
+        expect(UserLanguage.all.count).to eq(1)
       end
 
       it 'A user language cannot be created with user that doesnt exist' do        

--- a/spec/mutations/user_language/create_user_language_spec.rb
+++ b/spec/mutations/user_language/create_user_language_spec.rb
@@ -24,6 +24,8 @@ module Mutations
 
         expect(user_lang[:fluencyLevel]).to be_a(String)
         expect(user_lang[:fluencyLevel]).to eq('target')
+
+        expect(UserLanguage.all.count).to eq(1)
       end
 
       it 'A user language can be created with fluency level of native' do        
@@ -42,6 +44,8 @@ module Mutations
 
         expect(user_lang[:fluencyLevel]).to be_a(String)
         expect(user_lang[:fluencyLevel]).to eq('native')
+
+        expect(UserLanguage.all.count).to eq(0)
       end
 
       it 'A user language cannot be created with user that doesnt exist' do        
@@ -50,6 +54,8 @@ module Mutations
         parsed = JSON.parse(response.body, symbolize_names: true)
         
         expect(parsed[:errors][0][:message]).to eq('Cannot return null for non-nullable field UserLanguage.id')
+
+        expect(UserLanguage.all.count).to eq(0)
       end
 
       it 'A user language cannot be created with language that doesnt exist' do        
@@ -58,6 +64,8 @@ module Mutations
         parsed = JSON.parse(response.body, symbolize_names: true)
 
         expect(parsed[:errors][0][:message]).to eq('Cannot return null for non-nullable field UserLanguage.id')
+
+        expect(UserLanguage.all.count).to eq(0)
       end
 
       def query(language_id:, user_id:, fluency_level:)


### PR DESCRIPTION
### What was changed?
- Change fluency_level to input of integer instead of string
- Simplified the create user language resolver

### Have Tests Been Added?
- [ ] No.
- [ ] Yes, but all tests are not passing.
- [x] Yes, and all are passing.

### Tracking
- Closes #93 

### Tracking and Documentation Consistency:
- [x] Updated README where necessary
- [x] Added appropriate labels
- [x] Addressed any rubocop violations
- [x] Added comments on my pull request, particularly in hard-to-understand areas
