### PR TITLE
Fix create availability bug

### DIFF
--- a/app/graphql/mutations/availabilities/create_availability.rb
+++ b/app/graphql/mutations/availabilities/create_availability.rb
@@ -12,10 +12,12 @@ module Mutations
       end
 
       def schedule_pairing(availability)
-        open_slot = availability.find_availabilities_to_pair
-        pairing = Pairing.create_pairing(availability, open_slot) unless open_slot.nil?
-        availability.update(status: 'fulfilled') unless pairing.nil?
-        open_slot[0].update(status: 'fulfilled') unless pairing.nil?
+        open_slot = availability.availabilities_to_pair
+        unless open_slot.empty?
+          Pairing.create_pairing(availability, open_slot)
+          availability.update(status: 'fulfilled')
+          open_slot[0].update(status: 'fulfilled')
+        end
       end
     end
   end

--- a/app/graphql/mutations/availabilities/update_availability.rb
+++ b/app/graphql/mutations/availabilities/update_availability.rb
@@ -17,8 +17,8 @@ module Mutations
       end
 
       def schedule_pairing(availability)
-        unless availability.status == 'cancelled' || availability.status == 'fulfilled'
-          open_slot = availability.find_availabilities_to_pair
+        if availability.status == 'open'
+          open_slot = availability.availabilities_to_pair
           pairing = Pairing.create_pairing(availability, open_slot) unless open_slot.empty?
           availability.update(status: 'fulfilled') unless pairing.nil?
           open_slot[0].update(status: 'fulfilled') unless pairing.nil?

--- a/app/models/availability.rb
+++ b/app/models/availability.rb
@@ -7,17 +7,17 @@ class Availability < ApplicationRecord
 
   enum status: { 'open': 0, 'fulfilled': 1, 'cancelled': 2 }
 
-  def find_availabilities_to_pair
-    unless people_to_pair.empty?
-      Availability.where(start_date_time: start_date_time..end_date_time)
-                  .or(Availability.where(end_date_time: start_date_time..end_date_time))
-                  .or(Availability.where('availabilities.start_date_time < ?', start_date_time).where(
-                        'availabilities.end_date_time > ?', end_date_time
-                      ))
-                  .where.not(user_id: user_id)
-                  .where.not(user_id: user.blocked_ids)
-                  .where(status: 'open').where(user_id: people_to_pair.first.user_id)
-    end
+  def availabilities_to_pair
+    return [] if people_to_pair.empty?
+
+    Availability.where(start_date_time: start_date_time..end_date_time)
+                .or(Availability.where(end_date_time: start_date_time..end_date_time))
+                .or(Availability.where('availabilities.start_date_time < ?', start_date_time).where(
+                      'availabilities.end_date_time > ?', end_date_time
+                    ))
+                .where.not(user_id: user_id)
+                .where.not(user_id: user.blocked_ids)
+                .where(status: 'open').where(user_id: people_to_pair.first.user_id)
   end
 
   def people_to_pair

--- a/spec/models/availability_spec.rb
+++ b/spec/models/availability_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Availability, type: :model do
   it { should validate_presence_of :status }
 
   describe 'model methods' do
-    describe 'find_availabilities_to_pair' do 
+    describe 'availabilities_to_pair' do 
       it 'can schedule and create a pairing' do
         japanese = create(:language)
         english = create(:language)
@@ -22,7 +22,7 @@ RSpec.describe Availability, type: :model do
         availability = japanese_learning_english.availabilities.create(start_date_time: DateTime.new(2021, 1, 1, 14, 30), end_date_time: DateTime.new(2021, 1, 1, 15, 30), status: 0)
         english_learning_japanese.availabilities.create(start_date_time: DateTime.new(2021, 1, 1, 13, 30), end_date_time: DateTime.new(2021, 1, 1, 15, 45), status: 0)
         english_learning_japanese_two.availabilities.create(start_date_time: DateTime.new(2021, 1, 1, 13, 30), end_date_time: DateTime.new(2021, 1, 1, 15, 45), status: 0)
-        available_people = availability.find_availabilities_to_pair
+        available_people = availability.availabilities_to_pair
 
         expect(available_people.size).to eq(1)
         expect(available_people.first.user_id).to eq(english_learning_japanese.id).or eq(english_learning_japanese_two.id)
@@ -40,7 +40,7 @@ RSpec.describe Availability, type: :model do
         BlockedPairing.create(blocking_user: japanese_learning_english, blocked_user: english_learning_japanese)
         availability = japanese_learning_english.availabilities.create(start_date_time: DateTime.new(2021, 1, 1, 14, 30), end_date_time: DateTime.new(2021, 1, 1, 15, 30), status: 0)
         english_learning_japanese.availabilities.create(start_date_time: DateTime.new(2021, 1, 1, 13, 30), end_date_time: DateTime.new(2021, 1, 1, 15, 30), status: 0)
-        available_people = availability.find_availabilities_to_pair
+        available_people = availability.availabilities_to_pair
 
         expect(available_people).to eq([])
       end

--- a/spec/mutations/availability/create_availability_spec.rb
+++ b/spec/mutations/availability/create_availability_spec.rb
@@ -4,20 +4,20 @@ module Mutations
   module Availabilities
     RSpec.describe CreateAvailability, type: :request do
       before :each do
-        @user = User.create(email: 'JB@email.com', username: 'Jim Bobby', password: '1234')
+        @jp_learning_eng_user = create(:user)
         @start_dt = DateTime.new(2021, 1, 1, 9, 30).to_i
         @end_dt = DateTime.new(2021, 1, 1, 12, 30).to_i
-        @language1 = create(:language)
-        @language2 = create(:language)
-        create(:user_language, :native, language: @language1, user: @user)
-        create(:user_language, :target, language: @language2, user: @user)
+        @japanese = create(:language, name: 'Japanese')
+        @english = create(:language, name: 'English')
+        create(:user_language, :native, language: @japanese, user: @jp_learning_eng_user)
+        create(:user_language, :target, language: @english, user: @jp_learning_eng_user)
       end
 
       it 'An availability can be created with default status of open' do
         post graphql_path, params: { query:
           "mutation {
           createAvailability(input: { params: {
-            userId: #{@user.id}
+            userId: #{@jp_learning_eng_user.id}
             startDateTime: 1609489800
             endDateTime: 1609504200
           }}) {
@@ -31,31 +31,31 @@ module Mutations
 
         json = JSON.parse(response.body, symbolize_names: true)
         expect(json[:data][:createAvailability][:id]).to_not be(nil)
-        expect(json[:data][:createAvailability][:userId]).to eq(@user.id.to_s)
+        expect(json[:data][:createAvailability][:userId]).to eq(@jp_learning_eng_user.id.to_s)
         expect(json[:data][:createAvailability][:startDateTime]).to eq('1609489800')
         expect(json[:data][:createAvailability][:endDateTime]).to eq('1609504200')
         expect(json[:data][:createAvailability][:status]).to eq('open')
       end
 
       it 'An availability can be created as fulfilled' do
-        post graphql_path, params: { query: query(status: 1) }
+        post graphql_path, params: { query: query(user_id: @jp_learning_eng_user.id, status: 1) }
         parsed = JSON.parse(response.body, symbolize_names: true)
         avail = parsed[:data][:createAvailability]
 
         expect(avail[:id]).to_not be(nil)
-        expect(avail[:userId]).to eq(@user.id.to_s)
+        expect(avail[:userId]).to eq(@jp_learning_eng_user.id.to_s)
         expect(avail[:startDateTime]).to eq(@start_dt.to_s)
         expect(avail[:endDateTime]).to eq(@end_dt.to_s)
         expect(avail[:status]).to eq('fulfilled')
       end
 
       it 'An availability can be created as cancelled' do
-        post graphql_path, params: { query: query(status: 2) }
+        post graphql_path, params: { query: query(user_id: @jp_learning_eng_user.id, status: 2) }
         parsed = JSON.parse(response.body, symbolize_names: true)
         avail = parsed[:data][:createAvailability]
 
         expect(avail[:id]).to_not be(nil)
-        expect(avail[:userId]).to eq(@user.id.to_s)
+        expect(avail[:userId]).to eq(@jp_learning_eng_user.id.to_s)
         expect(avail[:startDateTime]).to eq(@start_dt.to_s)
         expect(avail[:endDateTime]).to eq(@end_dt.to_s)
         expect(avail[:status]).to eq('cancelled')
@@ -68,12 +68,12 @@ module Mutations
           end_dt = DateTime.new(2021, 1, 1, 15, 30).to_i
           english_learning_japanese = create(:user, id: 2)
           english_learning_japanese_two = create(:user, id: 3)
-          create(:user_language, :native, language: @language1, user: japanese_learning_english)
-          create(:user_language, :target, language: @language2, user: japanese_learning_english)
-          create(:user_language, :native, language: @language2, user: english_learning_japanese)
-          create(:user_language, :target, language: @language1, user: english_learning_japanese)
-          create(:user_language, :native, language: @language2, user: english_learning_japanese_two)
-          create(:user_language, :target, language: @language1, user: english_learning_japanese_two)
+          create(:user_language, :native, language: @japanese, user: japanese_learning_english)
+          create(:user_language, :target, language: @english, user: japanese_learning_english)
+          create(:user_language, :native, language: @english, user: english_learning_japanese)
+          create(:user_language, :target, language: @japanese, user: english_learning_japanese)
+          create(:user_language, :native, language: @english, user: english_learning_japanese_two)
+          create(:user_language, :target, language: @japanese, user: english_learning_japanese_two)
           english_learning_japanese.availabilities.create(start_date_time: DateTime.new(2021, 1, 1, 13, 30), end_date_time: DateTime.new(2021, 1, 1, 15, 45), status: 0)
           english_learning_japanese_two.availabilities.create(start_date_time: DateTime.new(2021, 1, 1, 13, 30), end_date_time: DateTime.new(2021, 1, 1, 15, 45), status: 0)
 
@@ -93,7 +93,6 @@ module Mutations
           }" }
 
           json = JSON.parse(response.body, symbolize_names: true)
-          
           avail = json[:data][:createAvailability]
           
           expect(avail[:id]).to_not be(nil)
@@ -104,13 +103,32 @@ module Mutations
           
           expect(Pairing.all.size).to eq(1)
         end
+
+        it 'when another user with opposite language goals but no availability exists, the availability can still be created' do
+          eng_learning_jp_user = create(:user)
+          create(:user_language, :native, language: @english, user: eng_learning_jp_user)
+          create(:user_language, :target, language: @japanese, user: eng_learning_jp_user)
+
+          post graphql_path, params: { query: query(user_id: eng_learning_jp_user.id, status: 0) }
+
+          json = JSON.parse(response.body, symbolize_names: true)
+          avail = json[:data][:createAvailability]
+
+          expect(avail[:id]).to_not be(nil)
+          expect(avail[:userId]).to eq(eng_learning_jp_user.id.to_s)
+          expect(avail[:startDateTime]).to eq(@start_dt.to_s)
+          expect(avail[:endDateTime]).to eq(@end_dt.to_s)
+          expect(avail[:status]).to eq('open')
+          
+          expect(Pairing.all.size).to eq(0)
+        end
       end
 
-      def query(status:)
+      def query(user_id:, status:)
         <<~GQL
           mutation {
             createAvailability(input: { params: {
-              userId: #{@user.id}
+              userId: #{user_id}
               startDateTime: #{@start_dt}
               endDateTime: #{@end_dt}
               status: #{status}

--- a/spec/mutations/availability/create_availability_spec.rb
+++ b/spec/mutations/availability/create_availability_spec.rb
@@ -37,49 +37,6 @@ module Mutations
         expect(json[:data][:createAvailability][:status]).to eq('open')
       end
 
-      it 'when an availability is created it tries to pair the user' do
-        japanese_learning_english = create(:user, id: 1)
-        start_dt = DateTime.new(2021, 1, 1, 14, 30).to_i
-        end_dt = DateTime.new(2021, 1, 1, 15, 30).to_i
-        english_learning_japanese = create(:user, id: 2)
-        english_learning_japanese_two = create(:user, id: 3)
-        create(:user_language, :native, language: @language1, user: japanese_learning_english)
-        create(:user_language, :target, language: @language2, user: japanese_learning_english)
-        create(:user_language, :native, language: @language2, user: english_learning_japanese)
-        create(:user_language, :target, language: @language1, user: english_learning_japanese)
-        create(:user_language, :native, language: @language2, user: english_learning_japanese_two)
-        create(:user_language, :target, language: @language1, user: english_learning_japanese_two)
-        english_learning_japanese.availabilities.create(start_date_time: DateTime.new(2021, 1, 1, 13, 30), end_date_time: DateTime.new(2021, 1, 1, 15, 45), status: 0)
-        english_learning_japanese_two.availabilities.create(start_date_time: DateTime.new(2021, 1, 1, 13, 30), end_date_time: DateTime.new(2021, 1, 1, 15, 45), status: 0)
-
-        post '/graphql', params: { query:
-          "mutation {
-          createAvailability(input: { params: {
-            userId: #{japanese_learning_english.id}
-            startDateTime: #{start_dt}
-            endDateTime: #{end_dt}
-          }}) {
-            id
-            userId
-            startDateTime
-            endDateTime
-            status
-          }
-        }" }
-
-        json = JSON.parse(response.body, symbolize_names: true)
-        
-        avail = json[:data][:createAvailability]
-        
-        expect(avail[:id]).to_not be(nil)
-        expect(avail[:userId]).to eq(japanese_learning_english.id.to_s)
-        expect(avail[:startDateTime]).to eq(start_dt.to_s)
-        expect(avail[:endDateTime]).to eq(end_dt.to_s)
-        expect(avail[:status]).to eq('fulfilled')
-        
-        expect(Pairing.all.size).to eq(1)
-      end
-
       it 'An availability can be created as fulfilled' do
         post graphql_path, params: { query: query(status: 1) }
         parsed = JSON.parse(response.body, symbolize_names: true)
@@ -102,6 +59,51 @@ module Mutations
         expect(avail[:startDateTime]).to eq(@start_dt.to_s)
         expect(avail[:endDateTime]).to eq(@end_dt.to_s)
         expect(avail[:status]).to eq('cancelled')
+      end
+
+      describe 'pairing creation attempts' do
+        it 'when an availability is created it tries to pair the user' do
+          japanese_learning_english = create(:user, id: 1)
+          start_dt = DateTime.new(2021, 1, 1, 14, 30).to_i
+          end_dt = DateTime.new(2021, 1, 1, 15, 30).to_i
+          english_learning_japanese = create(:user, id: 2)
+          english_learning_japanese_two = create(:user, id: 3)
+          create(:user_language, :native, language: @language1, user: japanese_learning_english)
+          create(:user_language, :target, language: @language2, user: japanese_learning_english)
+          create(:user_language, :native, language: @language2, user: english_learning_japanese)
+          create(:user_language, :target, language: @language1, user: english_learning_japanese)
+          create(:user_language, :native, language: @language2, user: english_learning_japanese_two)
+          create(:user_language, :target, language: @language1, user: english_learning_japanese_two)
+          english_learning_japanese.availabilities.create(start_date_time: DateTime.new(2021, 1, 1, 13, 30), end_date_time: DateTime.new(2021, 1, 1, 15, 45), status: 0)
+          english_learning_japanese_two.availabilities.create(start_date_time: DateTime.new(2021, 1, 1, 13, 30), end_date_time: DateTime.new(2021, 1, 1, 15, 45), status: 0)
+
+          post '/graphql', params: { query:
+            "mutation {
+            createAvailability(input: { params: {
+              userId: #{japanese_learning_english.id}
+              startDateTime: #{start_dt}
+              endDateTime: #{end_dt}
+            }}) {
+              id
+              userId
+              startDateTime
+              endDateTime
+              status
+            }
+          }" }
+
+          json = JSON.parse(response.body, symbolize_names: true)
+          
+          avail = json[:data][:createAvailability]
+          
+          expect(avail[:id]).to_not be(nil)
+          expect(avail[:userId]).to eq(japanese_learning_english.id.to_s)
+          expect(avail[:startDateTime]).to eq(start_dt.to_s)
+          expect(avail[:endDateTime]).to eq(end_dt.to_s)
+          expect(avail[:status]).to eq('fulfilled')
+          
+          expect(Pairing.all.size).to eq(1)
+        end
       end
 
       def query(status:)


### PR DESCRIPTION
### What was changed?
- Was previously getting 500 error when: 
  - Create two users with opposite language learning goals (they could be paired)
  - Don't create any availabilities
  - Attempt to create an availability for either user 
- To fix: return empty array instead of nil when return availabilities_to_pair (availability model) doesn't have any matching availabilities
  - This was throwing an error because when there's an existing user with opposite language goals and no matching availabilities, the return value is []. When there's no user with opposite language goals, the return value was nil. So I standardized the return value to always be an array for handling in schedule_pairing.

### Message/Questions for reviewer:

### Have Tests Been Added?
- [ ] No.
- [ ] Yes, but all tests are not passing.
- [x] Yes, and all are passing.

### Issues:
* Closes #95

### Tracking and Documentation Consistency:
- [x] Updated README where necessary
- [x] Added appropriate labels
- [x] Addressed any rubocop violations
- [x] Added comments on my pull request, particularly in hard-to-understand areas
