### PR TITLE
Don't allow for duplicate blocked pairings to be created

### DIFF
--- a/app/graphql/mutations/blocked_pairings/create_blocked_pairing.rb
+++ b/app/graphql/mutations/blocked_pairings/create_blocked_pairing.rb
@@ -7,10 +7,18 @@ module Mutations
 
       def resolve(params:)
         blocked_pairing_params = Hash params
+        return handle_already_exists_error if BlockedPairing.blocked_pairing_exists?(
+          blocked_pairing_params[:blocking_user_id], blocked_pairing_params[:blocked_user_id]
+        )
+
         BlockedPairing.create(
           blocking_user_id: blocked_pairing_params[:blocking_user_id],
           blocked_user_id: blocked_pairing_params[:blocked_user_id]
         )
+      end
+
+      def handle_already_exists_error
+        GraphQL::ExecutionError.new('this user has already been blocked')
       end
     end
   end

--- a/app/models/blocked_pairing.rb
+++ b/app/models/blocked_pairing.rb
@@ -1,4 +1,8 @@
 class BlockedPairing < ApplicationRecord
   belongs_to :blocking_user, class_name: 'User'
   belongs_to :blocked_user, class_name: 'User'
+
+  def self.blocked_pairing_exists?(blocking_user_id, blocked_user_id)
+    !BlockedPairing.where(blocking_user_id: blocking_user_id, blocked_user_id: blocked_user_id).empty?
+  end
 end

--- a/spec/models/blocked_pairing_spec.rb
+++ b/spec/models/blocked_pairing_spec.rb
@@ -5,4 +5,17 @@ RSpec.describe BlockedPairing, type: :model do
     it { should belong_to :blocking_user }
     it { should belong_to :blocked_user }
   end
+
+  describe 'class methods' do
+    describe 'blocked_pairing_exists?' do 
+      it 'can return whether or not a pairing has already been blocked' do
+        blocking_user = create :user
+        blocked_user = create :user
+        BlockedPairing.create(blocking_user_id: blocking_user.id, blocked_user_id: blocked_user.id)
+
+        expect(BlockedPairing.blocked_pairing_exists?(blocking_user.id, blocked_user.id)).to eq(true)
+        expect(BlockedPairing.blocked_pairing_exists?(blocked_user.id, blocking_user.id)).to eq(false)
+      end
+    end
+  end
 end

--- a/spec/mutations/blocked_pairing/create_blocked_pairing_spec.rb
+++ b/spec/mutations/blocked_pairing/create_blocked_pairing_spec.rb
@@ -23,6 +23,15 @@ module Mutations
         expect(blocked_pair[:blockedUserId]).to eq(@blocked.id.to_s)
       end
 
+      it 'user cannot create more than one blocked pairing for another user' do
+        BlockedPairing.create(blocking_user_id: @blocker.id, blocked_user_id: @blocked.id)
+
+        post graphql_path, params: { query: query(blocking_user_id: @blocker.id, blocked_user_id: @blocked.id) }
+        
+        parsed = JSON.parse(response.body, symbolize_names: true)
+        expect(parsed[:errors][0][:message]).to eq('this user has already been blocked')
+      end
+
       def query(blocking_user_id:, blocked_user_id:)
         <<~GQL
           mutation {


### PR DESCRIPTION
### What was changed?
- Before: client could create endless blocked pairing records for same blocking and blocked user
- Now: error message `this user has already been blocked` if client tries to create duplicate

### Have Tests Been Added?
- [ ] No.
- [ ] Yes, but all tests are not passing.
- [x] Yes, and all are passing.

### Issues:
* Closes #89

### Tracking and Documentation Consistency:
- [x] Updated README where necessary
- [x] Added appropriate labels
- [x] Addressed any rubocop violations
- [x] Added comments on my pull request, particularly in hard-to-understand areas
