### PR TITLE
User cannot create duplicate user languages

### DIFF
--- a/app/graphql/mutations/availabilities/create_availability.rb
+++ b/app/graphql/mutations/availabilities/create_availability.rb
@@ -6,7 +6,7 @@ module Mutations
 
       def resolve(params:)
         availability_params = Hash params
-        return handle_no_languages_error if User.find(availability_params[:user_id]).user_languages.empty?
+        return handle_no_languages_error unless User.find(availability_params[:user_id]).user_languages.exists?
 
         availability = Availability.create(availability_params)
         schedule_pairing(availability) if availability

--- a/app/graphql/mutations/user_languages/create_user_language.rb
+++ b/app/graphql/mutations/user_languages/create_user_language.rb
@@ -13,8 +13,7 @@ module Mutations
       end
 
       def user_language_exists?(params)
-        !UserLanguage.where(user: params[:user_id], language: params[:language_id],
-                            fluency_level: params[:fluency_level]).empty?
+        UserLanguage.where(user: params[:user_id], language: params[:language_id],fluency_level: params[:fluency_level]).exists?
       end
 
       def handle_duplicate_user_lang

--- a/app/graphql/mutations/user_languages/create_user_language.rb
+++ b/app/graphql/mutations/user_languages/create_user_language.rb
@@ -5,7 +5,20 @@ module Mutations
       type Types::UserLanguageType
 
       def resolve(params:)
+        user_lang_params = Hash params
+
+        return handle_duplicate_user_lang if user_language_exists?(user_lang_params)
+
         UserLanguage.create(params.to_hash)
+      end
+
+      def user_language_exists?(params)
+        !UserLanguage.where(user: params[:user_id], language: params[:language_id],
+                            fluency_level: params[:fluency_level]).empty?
+      end
+
+      def handle_duplicate_user_lang
+        GraphQL::ExecutionError.new('User already has this language and fluency level')
       end
     end
   end

--- a/app/graphql/mutations/user_languages/create_user_language.rb
+++ b/app/graphql/mutations/user_languages/create_user_language.rb
@@ -13,7 +13,8 @@ module Mutations
       end
 
       def user_language_exists?(params)
-        UserLanguage.where(user: params[:user_id], language: params[:language_id],fluency_level: params[:fluency_level]).exists?
+        UserLanguage.exists?(user: params[:user_id], language: params[:language_id],
+                             fluency_level: params[:fluency_level])
       end
 
       def handle_duplicate_user_lang

--- a/spec/mutations/user_language/create_user_language_spec.rb
+++ b/spec/mutations/user_language/create_user_language_spec.rb
@@ -68,6 +68,17 @@ module Mutations
         expect(UserLanguage.all.count).to eq(0)
       end
 
+      it 'A duplicate language and fluency level cannot be created' do
+        UserLanguage.create(user: @user, language: @language, fluency_level: 0)
+        post graphql_path, params: { query: query(user_id: @user.id, language_id: @language.id, fluency_level: 0) }
+
+        parsed = JSON.parse(response.body, symbolize_names: true)
+
+        expect(parsed[:errors][0][:message]).to eq('User already has this language and fluency level')
+
+        expect(UserLanguage.all.count).to eq(1)
+      end
+
       def query(language_id:, user_id:, fluency_level:)
         <<~GQL
           mutation {


### PR DESCRIPTION
### What was changed?
- Before: user could create duplicate user languages (same language, user and fluency level)
- Now: error message for duplicate creation attemp

### Have Tests Been Added?
- [ ] No.
- [ ] Yes, but all tests are not passing.
- [x] Yes, and all are passing.

### Issues:
* Closes #101

### Tracking and Documentation Consistency:
- [x] Updated README where necessary
- [x] Added appropriate labels
- [x] Addressed any rubocop violations
- [x] Added comments on my pull request, particularly in hard-to-understand areas
